### PR TITLE
Fixing Polly_VTT so it uses the passed file name

### DIFF
--- a/polly_vtt/polly_vtt.py
+++ b/polly_vtt/polly_vtt.py
@@ -7,6 +7,6 @@ class PollyVTT:
         self.polly = Polly()
 
     def generate(self, filename, format="vtt", **polly_params):
-        resp, filename, length = self.polly.synthesize("testfile", **polly_params)
+        resp, filename, length = self.polly.synthesize(filename, **polly_params)
         vtt = VTT(AudioLengthInMs=length, PollyResponse=resp, Filename=filename, Format=format)
         vtt.write()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Fixing Polly_VTT so it uses the passed file name.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
